### PR TITLE
Update debian.md

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -151,7 +151,7 @@ Docker from the repository.
    To install the latest version, run:
 
    ```console
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin cgroupfs-mount
    ```
 
    </div>


### PR DESCRIPTION
Fixes docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.